### PR TITLE
fix: capitalization of WebCam include

### DIFF
--- a/src/devices/SurfingWebcam.cpp
+++ b/src/devices/SurfingWebcam.cpp
@@ -1,4 +1,4 @@
-#include "SurfingWebCam.h"
+#include "SurfingWebcam.h"
 
 //--------------------------------------------------------------
 void SurfingWebCam::setupWebCamDevice() {


### PR DESCRIPTION
otherwise errors on case-sensitive filesystems